### PR TITLE
fixed a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Useful pre-compiled TON binaries (`fift`, `func`, `lite-client`) for multiple op
 
 3. To check that everything was installed correctly, run in terminal `fift -V && func -V && lite-client -V`
 
-4. If you plan to use `fift`, also download [fiftlib.zip](https://github.com/ton-defi-org/ton-binaries/releases/download/fiftlib/fiftlib.zip), open the zip in some directory on your machine (like `/usr/local/lib/fiftlib`) and set the environment variable `FIFTPATH` to point to this directory.
+4. If you plan to use `fift`, also download [fiftlib.zip](https://github.com/ton-defi-org/ton-binaries/releases/download/ubuntu-18-0.3.0/fiftlib.zip), open the zip in some directory on your machine (like `/usr/local/lib/fiftlib`) and set the environment variable `FIFTPATH` to point to this directory.
 
 ## Alternative - compile by yourself
 


### PR DESCRIPTION
The fiftlib.zip link was broken since the whole "fiftlib" release seems to be missing. Replaced it with the link to the fiftlib.zip from the "ubuntu-18-0.3.0" release (I guess the archive is exactly the same for any OS and is not Ubuntu-specific?)